### PR TITLE
emove peerdep install

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,11 @@
     "jshint-stylish": "^2.2.1",
     "load-grunt-configs": "^1.0.0",
     "must": "^0.13.4",
-    "peerdep": "^0.1.0",
     "proxyquire": "^1.7.11",
     "sinon": "^1.17.7",
     "time-grunt": "^1.4.0"
   },
   "scripts": {
-    "test": "grunt",
-    "install": "peerdep"
+    "test": "grunt"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restful-keystone",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Automatic RESTful API enabler for KeystoneJS",
   "author": {
     "name": "d-pac",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restful-keystone",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Automatic RESTful API enabler for KeystoneJS",
   "author": {
     "name": "d-pac",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "api"
   ],
   "dependencies": {
-    "lodash": "^3.2.0",
-    "debug": "^2.1.1",
-    "errors": "^0.2.0",
-    "bluebird": "^2.9.9",
-    "require-directory": "^2.0.0",
+    "bluebird": "^3.4.7",
+    "debug": "^2.6.0",
+    "deepmerge": "^1.3.2",
+    "errors": "^0.3.0",
+    "lodash": "^4.17.4",
     "node-constants": "0.0.2",
-    "deepmerge": "^0.2.7"
+    "require-directory": "^2.1.1"
   },
   "peerDependencies": {
     "keystone": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "api"
   ],
   "dependencies": {
-    "peerdep": "^0.1.0",
     "lodash": "^3.2.0",
     "debug": "^2.1.1",
     "errors": "^0.2.0",
@@ -34,17 +33,19 @@
     "keystone": "^0.3.0"
   },
   "devDependencies": {
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-jshint": "^0.10.0",
-    "time-grunt": "^1.0.0",
-    "grunt-mocha-cli": "^1.11.0",
-    "jshint-stylish": "^1.0.0",
-    "jit-grunt": "^0.9.1",
-    "load-grunt-configs": "^0.4.2",
-    "grunt-jscs": "^1.5.0",
-    "must": "^0.12.0",
-    "sinon": "^1.12.2",
-    "proxyquire": "^1.3.1"
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-jscs": "^3.0.1",
+    "grunt-mocha-cli": "^3.0.0",
+    "jit-grunt": "^0.10.0",
+    "jshint-stylish": "^2.2.1",
+    "load-grunt-configs": "^1.0.0",
+    "must": "^0.13.4",
+    "peerdep": "^0.1.0",
+    "proxyquire": "^1.7.11",
+    "sinon": "^1.17.7",
+    "time-grunt": "^1.4.0"
   },
   "scripts": {
     "test": "grunt",


### PR DESCRIPTION
the package.json scripts: { "install": "peerdep" } was causing path not found errors when npm installed in a keystone project.